### PR TITLE
Deployment Helper Workflow

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -1,0 +1,27 @@
+name: Deploy PR preview
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Install and Build
+        run: |
+          npm install
+          npm run build
+
+      - name: Deploy PR Preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./build/

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Deploy PR Preview
         uses: rossjrw/pr-preview-action@v1
         with:
-          source-dir: ./build/
+          source-dir: ./.output/public

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -9,6 +9,9 @@ on:
 concurrency: preview-${{ github.ref }}
 jobs:
   deploy-preview:
+    permissions:
+      pages: write
+      id-token: write
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
@@ -20,10 +23,12 @@ jobs:
         with:
           node-version: "18"
           check-latest: true
-      - name: Install and Build
+      - name: Install and Build using pnpm
         run: |
           pnpm install
           pnpm run build
+        env:
+          NITRO_PRESET: github_pages
       - name: Deploy PR Preview
         uses: rossjrw/pr-preview-action@v1
         with:

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -1,5 +1,4 @@
 name: Deploy PR preview
-
 on:
   pull_request:
     types:
@@ -8,19 +7,23 @@ on:
       - synchronize
 
 concurrency: preview-${{ github.ref }}
-
 jobs:
   deploy-preview:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-
+      - name: Enable CorePack
+        run: corepack enable
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          check-latest: true
       - name: Install and Build
         run: |
-          npm install
-          npm run build
-
+          pnpm install
+          pnpm run build
       - name: Deploy PR Preview
         uses: rossjrw/pr-preview-action@v1
         with:


### PR DESCRIPTION
Resolves #68 by adding a deployment helper for previewing pull requested builds, This is however a draft as there are some things that have to be done before hand.

- [x] Build the initial workflow,
- [ ] Figure out how to deal with the permsisions error,
- [ ] Prevent main deployment from getting pwned,
- [ ] Prevent force-push from being passed for safety,
- [ ] Configure everything else that's needed.